### PR TITLE
chore: fix build output; the editor.js modules is not genereted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /coverage.data
 /coverage/
 
-/dist
+**/dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/editor.umd.cjs",
-  "module": "./dist/editor.js",
+  "main": "./dist/index.umd.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js"


### PR DESCRIPTION
This merge request fixes an error in the `package.json` file. Basically, it only changes the `editor.js` output to the right file generated by the Vite output, `index.js`.

![CleanShot 2024-04-22 at 15 06 29](https://github.com/dodgydre/vuequill/assets/2914170/21846f31-5847-43ce-acff-057912759039)
